### PR TITLE
Add new category 'Melodic Percussion'

### DIFF
--- a/_data/sfz/instruments.yml
+++ b/_data/sfz/instruments.yml
@@ -285,6 +285,19 @@ categories:
       size: "716 MB"
       short_description: ""
 
+- name: "Keyboards"
+  page: "keyboards"
+  instruments:
+  - name:    "Sforzatron"
+    page:    "sforzatron"
+#   version: ""
+    author:  "Plogue"
+#   license: ""
+    url:     "https://www.plogue.com/products/sforzando-banks.html"
+#   download_size: ""
+    short_description:
+      "Here’s Plogue’s offering of the now famous Taijiguy Free Mellotron samples."
+
 - name: "Misc"
   page: "misc"
   instruments:
@@ -340,19 +353,6 @@ categories:
       samplerate: "44.1"
       size: "4.1 GB"
       short_description: "tar.gz archive"
-
-- name: "Keyboards"
-  page: "keyboards"
-  instruments:
-  - name:    "Sforzatron"
-    page:    "sforzatron"
-#   version: ""
-    author:  "Plogue"
-#   license: ""
-    url:     "https://www.plogue.com/products/sforzando-banks.html"
-#   download_size: ""
-    short_description:
-      "Here’s Plogue’s offering of the now famous Taijiguy Free Mellotron samples."
 
 - name: "Orchestra"
   page: "orchestra"

--- a/_data/sfz/instruments.yml
+++ b/_data/sfz/instruments.yml
@@ -298,6 +298,10 @@ categories:
     short_description:
       "Here’s Plogue’s offering of the now famous Taijiguy Free Mellotron samples."
 
+- name: "Melodic Percussion"
+  page: "melodic-percussion"
+  instruments: []
+
 - name: "Misc"
   page: "misc"
   instruments:

--- a/melodic-percussion/index.md
+++ b/melodic-percussion/index.md
@@ -1,0 +1,6 @@
+---
+title:  "Melodic Percussion"
+layout: "no_title"
+---
+{%-comment-%} See https://sfzinstruments.github.io/docs/adding-instruments {%-endcomment-%}
+{% include sfz/instruments_table.html %}


### PR DESCRIPTION
For mallet instruments (Vibes, Xylophone, Marimba, etc.), Hang, Tubular Bells etc. (see also: https://en.wikipedia.org/wiki/Melodic_percussion_instrument).

Should be rebased after merge of #1.