### PR TITLE
Allow Ruby versions 2.7.0 -> 2.7.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 # - https://docs.travis-ci.com/user/languages/ruby/#default-build-script
 # - https://github.com/travis-ci/travis-web/blob/master/Gemfile
 
-ruby "2.7.1"
+ruby ">= 2.7.0", "<= 2.7.6"
 group :development, :test do
   gem "rake", "~> 12"
 end


### PR DESCRIPTION
Installing Ruby 2.7.x on a mac you would go to:
https://www.ruby-lang.org/en/downloads/
https://formulae.brew.sh/formula/ruby@2.7

In both places the recommended/table version is `2.7.6`
By changing the version filter we allow the site to run and build on any of those minor versions